### PR TITLE
Do not supposedly sign headers that are not present in the mail

### DIFF
--- a/dkim_test.go
+++ b/dkim_test.go
@@ -307,7 +307,7 @@ func Test_Sign(t *testing.T) {
 	options.Domain = domain
 	options.Selector = selector
 	//options.SignatureExpireIn = 3600
-	options.Headers = []string{"from", "date", "mime-version", "received", "received"}
+	options.Headers = []string{"from", "date", "mime-version", "received", "received", "cc"}
 	options.AddSignatureTimestamp = false
 
 	options.Canonicalization = "relaxed/relaxed"


### PR DESCRIPTION
go-dkim will announce in the DKIM header that it signs headers that might not be present in the mail.
While this SHOULD be possible according to the RFC, some mail providers (looking at you, Micro$oft) will mark the signature to be invalid due to this.